### PR TITLE
GN-4 Fix autocomplete URLs

### DIFF
--- a/examples/examples.json
+++ b/examples/examples.json
@@ -19,7 +19,7 @@
 					"environment": "beta"
 				},
 				"search": {
-					"autocomplete": "/niceorg/autocomplete?ajax=ajax"
+					"autocomplete": "/niceorg/autocomplete/?ajax=ajax"
 				}
 			}
 		}
@@ -34,7 +34,7 @@
 					"environment": "test"
 				},
 				"search": {
-					"autocomplete": "/niceorg/autocomplete?ajax=ajax"
+					"autocomplete": "/niceorg/autocomplete/?ajax=ajax"
 				}
 			}
 		}
@@ -60,7 +60,7 @@
 				"search": {
 					"placeholder": "Search evidence…",
 					"query": "diabetes",
-					"autocomplete": "/evidence/autocomplete?ajax=ajax"
+					"autocomplete": "/evidence/autocomplete/?ajax=ajax"
 				}
 			}
 		}
@@ -73,7 +73,7 @@
 			"header": {
 				"search": {
 					"placeholder": "Search BNF…",
-					"autocomplete": "/bnf/typeahead?ajax=ajax"
+					"autocomplete": "/bnf/typeahead/?ajax=ajax"
 				}
 			}
 		}
@@ -86,7 +86,7 @@
 			"header": {
 				"search": {
 					"placeholder": "Search BNFC…",
-					"autocomplete": "/bnfc/typeahead?ajax=ajax"
+					"autocomplete": "/bnfc/typeahead/?ajax=ajax"
 				}
 			}
 		}
@@ -111,7 +111,7 @@
 			"service": "journals",
 			"header": {
 				"search": {
-					"autocomplete": "/niceorg/autocomplete?ajax=ajax"
+					"autocomplete": "/niceorg/autocomplete/?ajax=ajax"
 				}
 			}
 		}


### PR DESCRIPTION
The test server was redirecting url like https://.../autocomplete to http://.../autocomplete/
which became an insecure request from https so browsers blocked it. This shouldn't be an issue
on live but we fix it here on the test site for testing purposes.